### PR TITLE
feat: implement documentation agent with tools for Task 2

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,8 +1,8 @@
-# Agent Documentation
+# Documentation Agent
 
 ## Overview
 
-This agent is a CLI program that takes a question as input, sends it to an LLM, and returns a structured JSON answer.
+This agent is a CLI program that answers questions using the project wiki. It has **tools** (`read_file`, `list_files`) that allow it to navigate and read files from the project repository, and an **agentic loop** that enables it to make multiple tool calls before providing a final answer.
 
 ## Architecture
 
@@ -16,31 +16,79 @@ This agent is a CLI program that takes a question as input, sends it to an LLM, 
 - 1000 free requests per day
 - Works from Russia without restrictions
 - No credit card required
-- OpenAI-compatible API
+- OpenAI-compatible API with tool calling support
 - Strong reasoning capabilities
 
 ### Components
 
 | Component | Description |
 |-----------|-------------|
-| `agent.py` | Main CLI script that handles input/output and LLM communication |
+| `agent.py` | Main CLI script with tools and agentic loop |
 | `.env.agent.secret` | Environment configuration (API key, base URL, model) |
 | `qwen-code-oai-proxy` | Local proxy that exposes Qwen Code via OpenAI-compatible API |
 
-## How It Works
+### Tools
+
+The agent has two tools:
+
+#### `read_file`
+
+Read the contents of a file from the project repository.
+
+**Parameters:**
+- `path` (string, required): Relative path from project root (e.g., `wiki/git-workflow.md`)
+
+**Returns:** File contents as a string, or an error message if the file doesn't exist.
+
+**Security:**
+- Rejects absolute paths
+- Rejects path traversal (`../`)
+- Only allows files within project root
+
+#### `list_files`
+
+List files and directories at a given path.
+
+**Parameters:**
+- `path` (string, required): Relative directory path from project root (e.g., `wiki`)
+
+**Returns:** Newline-separated listing of entries.
+
+**Security:**
+- Rejects absolute paths
+- Rejects path traversal (`../`)
+- Only allows directories within project root
+
+## Agentic Loop
+
+The agentic loop enables the agent to:
+1. Send the user's question + tool definitions to the LLM
+2. If the LLM responds with `tool_calls` → execute each tool, append results as `tool` role messages, go to step 1
+3. If the LLM responds with a text message (no tool calls) → that's the final answer
+4. If 10 tool calls are reached → stop looping and provide whatever answer is available
 
 ```
-┌─────────────────┐     ┌──────────┐     ┌─────────────────────┐     ┌──────────┐
-│ User Question   │ ──→ │ agent.py │ ──→ │ Qwen Code API       │ ──→ │ JSON     │
-│ (CLI argument)  │     │          │     │ (via local proxy)   │     │ Response │
-└─────────────────┘     └──────────┘     └─────────────────────┘     └──────────┘
+Question ──▶ LLM ──▶ tool call? ──yes──▶ execute tool ──▶ back to LLM
+                     │
+                     no
+                     │
+                     ▼
+                JSON output
 ```
 
-1. User provides a question as a command-line argument
-2. `agent.py` loads configuration from `.env.agent.secret`
-3. Agent sends HTTP POST request to the LLM API
-4. LLM returns the answer
-5. Agent outputs JSON with `answer` and `tool_calls` fields
+### Loop Limits
+
+- Maximum 10 tool calls per question
+- Timeout: 60 seconds per LLM request
+
+## System Prompt Strategy
+
+The system prompt instructs the LLM to:
+1. Use `list_files` to discover wiki directory structure
+2. Use `read_file` to read relevant wiki files
+3. Find the specific section that answers the question
+4. Include the source reference (file path + section anchor)
+5. Only make tool calls when necessary
 
 ## Usage
 
@@ -50,15 +98,16 @@ This agent is a CLI program that takes a question as input, sends it to an LLM, 
 uv run agent.py "Your question here"
 ```
 
-### Example
+### Examples
 
+**List wiki files:**
 ```bash
-uv run agent.py "What does REST stand for?"
+uv run agent.py "What files are in the wiki?"
 ```
 
-**Output:**
-```json
-{"answer": "REST stands for **Representational State Transfer**.", "tool_calls": []}
+**Find information about merge conflicts:**
+```bash
+uv run agent.py "How do you resolve a merge conflict?"
 ```
 
 ### Output Format
@@ -67,13 +116,26 @@ The agent outputs a single JSON line to stdout:
 
 ```json
 {
-  "answer": "The LLM's response text",
-  "tool_calls": []
+  "answer": "The answer text from the LLM",
+  "source": "wiki/git-workflow.md#resolving-merge-conflicts",
+  "tool_calls": [
+    {
+      "tool": "list_files",
+      "args": {"path": "wiki"},
+      "result": "git-workflow.md\n..."
+    },
+    {
+      "tool": "read_file",
+      "args": {"path": "wiki/git-workflow.md"},
+      "result": "..."
+    }
+  ]
 }
 ```
 
-- `answer`: String containing the LLM's response
-- `tool_calls`: Array of tool calls (empty for Task 1)
+- `answer` (string, required): The LLM's response text
+- `source` (string, required): The wiki section reference (e.g., `wiki/git-workflow.md#section-anchor`)
+- `tool_calls` (array, required): All tool calls made during the agentic loop
 
 **Note:** All debug/logging output goes to stderr, only the JSON result goes to stdout.
 
@@ -118,23 +180,25 @@ LLM_MODEL=qwen3-coder-plus
 
 - **Missing question:** Prints usage to stderr, exits with code 1
 - **Missing config:** Prints error to stderr, exits with code 1
-- **Network error:** Prints error to stderr, exits with code 1
-- **Invalid LLM response:** Prints error to stderr, exits with code 1
+- **Network error:** Returns error in JSON, exits with code 0
+- **Invalid LLM response:** Returns error in JSON, exits with code 0
+- **Max tool calls reached:** Returns partial answer with tool calls made
 
 ## Testing
 
-Run the regression test:
+Run the regression tests:
 
 ```bash
-uv run pytest backend/tests/test_agent.py -v
+uv run pytest tests/test_agent.py -v
 ```
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `agent.py` | Main agent CLI |
+| `agent.py` | Main agent CLI with tools and agentic loop |
 | `.env.agent.secret` | LLM configuration (not committed to git) |
 | `AGENT.md` | This documentation |
-| `plans/task-1.md` | Implementation plan |
-| `backend/tests/test_agent.py` | Regression tests |
+| `plans/task-1.md` | Task 1 implementation plan |
+| `plans/task-2.md` | Task 2 implementation plan |
+| `tests/test_agent.py` | Regression tests |

--- a/agent.py
+++ b/agent.py
@@ -1,23 +1,30 @@
 #!/usr/bin/env python3
 """
-Agent CLI - Calls an LLM and returns a structured JSON answer.
+Documentation Agent CLI - Calls an LLM with tools to answer questions using the project wiki.
 
 Usage:
     uv run agent.py "Your question here"
 
 Output:
-    JSON with 'answer' and 'tool_calls' fields to stdout.
+    JSON with 'answer', 'source', and 'tool_calls' fields to stdout.
     All debug output goes to stderr.
 """
 
 import asyncio
 import json
 import os
+import re
 import sys
 from pathlib import Path
+from typing import Any
 
 import httpx
 from dotenv import load_dotenv
+
+# Maximum tool calls per question
+MAX_TOOL_CALLS = 10
+# Timeout for LLM requests in seconds
+LLM_TIMEOUT = 60.0
 
 
 def load_env() -> dict[str, str]:
@@ -41,8 +48,193 @@ def load_env() -> dict[str, str]:
     return config
 
 
-async def call_llm(question: str, config: dict[str, str]) -> str:
-    """Call the LLM API and return the answer."""
+def is_safe_path(path: str) -> bool:
+    """Check if path is safe (no traversal outside project root)."""
+    # Reject absolute paths
+    if path.startswith('/'):
+        return False
+    # Reject path traversal
+    parts = path.split('/')
+    if '..' in parts:
+        return False
+    # Reject paths starting with ../
+    if path.startswith('../'):
+        return False
+    return True
+
+
+def get_project_root() -> Path:
+    """Get the project root directory."""
+    return Path(__file__).parent
+
+
+def read_file(path: str) -> dict[str, Any]:
+    """
+    Read a file from the project repository.
+    
+    Args:
+        path: Relative path from project root
+        
+    Returns:
+        Dict with 'success' boolean and 'content' or 'error' message
+    """
+    if not is_safe_path(path):
+        return {"success": False, "error": f"Unsafe path: {path}"}
+    
+    project_root = get_project_root()
+    file_path = project_root / path
+    
+    if not file_path.exists():
+        return {"success": False, "error": f"File not found: {path}"}
+    
+    if not file_path.is_file():
+        return {"success": False, "error": f"Not a file: {path}"}
+    
+    try:
+        content = file_path.read_text()
+        return {"success": True, "content": content}
+    except Exception as e:
+        return {"success": False, "error": f"Error reading file: {e}"}
+
+
+def list_files(path: str) -> dict[str, Any]:
+    """
+    List files and directories at a given path.
+    
+    Args:
+        path: Relative directory path from project root
+        
+    Returns:
+        Dict with 'success' boolean and 'entries' list or 'error' message
+    """
+    if not is_safe_path(path):
+        return {"success": False, "error": f"Unsafe path: {path}"}
+    
+    project_root = get_project_root()
+    dir_path = project_root / path
+    
+    if not dir_path.exists():
+        return {"success": False, "error": f"Directory not found: {path}"}
+    
+    if not dir_path.is_dir():
+        return {"success": False, "error": f"Not a directory: {path}"}
+    
+    try:
+        entries = [entry.name for entry in dir_path.iterdir()]
+        return {"success": True, "entries": entries}
+    except Exception as e:
+        return {"success": False, "error": f"Error listing directory: {e}"}
+
+
+# Tool definitions for LLM function calling
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file",
+            "description": "Read the contents of a file from the project repository. Use this to read wiki files or other documentation.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative path from project root (e.g., 'wiki/git-workflow.md')"
+                    }
+                },
+                "required": ["path"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_files",
+            "description": "List files and directories at a given path in the project repository. Use this to explore directory structure.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative directory path from project root (e.g., 'wiki')"
+                    }
+                },
+                "required": ["path"]
+            }
+        }
+    }
+]
+
+# System prompt for the documentation agent
+SYSTEM_PROMPT = """You are a documentation agent that answers questions using the project wiki.
+
+You have access to two tools:
+- list_files: List files in a directory. Use this to explore the wiki directory structure.
+- read_file: Read contents of a file. Use this to read wiki files and find answers.
+
+To answer questions:
+1. Use list_files to explore the wiki directory and find relevant files
+2. Use read_file to read the contents of relevant files
+3. Find the specific section that answers the question
+4. Include the source as "filepath.md#section-anchor" format
+
+Always provide the source reference for your answer. The source should be the specific file and section that contains the answer.
+
+If the question is not about the project documentation, you can answer directly without using tools."""
+
+
+def execute_tool(name: str, args: dict[str, Any]) -> str:
+    """
+    Execute a tool and return the result as a string.
+    
+    Args:
+        name: Tool name
+        args: Tool arguments
+        
+    Returns:
+        Tool result as string
+    """
+    if name == "read_file":
+        path = args.get("path", "")
+        if not path:
+            return "Error: Missing required argument 'path'"
+        result = read_file(path)
+        if result["success"]:
+            # Truncate very long file contents
+            content = result["content"]
+            if len(content) > 4000:
+                content = content[:4000] + "\n... [truncated]"
+            return content
+        else:
+            return f"Error: {result['error']}"
+    elif name == "list_files":
+        path = args.get("path", "")
+        if not path:
+            return "Error: Missing required argument 'path'"
+        result = list_files(path)
+        if result["success"]:
+            return "\n".join(result["entries"])
+        else:
+            return f"Error: {result['error']}"
+    else:
+        return f"Error: Unknown tool '{name}'"
+
+
+async def call_llm(
+    messages: list[dict[str, Any]],
+    config: dict[str, str],
+    tools: list[dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    """
+    Call the LLM API and return the response.
+    
+    Args:
+        messages: Conversation messages
+        config: LLM configuration
+        tools: Optional tool definitions for function calling
+        
+    Returns:
+        LLM response data or None on error
+    """
     api_base = config["LLM_API_BASE"]
     api_key = config["LLM_API_KEY"]
     model = config["LLM_MODEL"]
@@ -52,29 +244,151 @@ async def call_llm(question: str, config: dict[str, str]) -> str:
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}",
     }
-    payload = {
+    payload: dict[str, Any] = {
         "model": model,
-        "messages": [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": question},
-        ],
+        "messages": messages,
     }
-    
-    print(f"Calling LLM at {url}...", file=sys.stderr)
-    
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        response = await client.post(url, headers=headers, json=payload)
-        response.raise_for_status()
-        data = response.json()
+    if tools:
+        payload["tools"] = tools
     
     try:
-        answer = data["choices"][0]["message"]["content"]
-    except (KeyError, IndexError) as e:
-        print(f"Error parsing LLM response: {e}", file=sys.stderr)
-        print(f"Response: {data}", file=sys.stderr)
-        sys.exit(1)
+        async with httpx.AsyncClient(timeout=LLM_TIMEOUT) as client:
+            response = await client.post(url, headers=headers, json=payload)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPStatusError as e:
+        print(f"HTTP error: {e}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"Error calling LLM: {e}", file=sys.stderr)
+        return None
+
+
+def extract_source(answer: str) -> str:
+    """Extract source reference from answer text."""
+    # Match patterns like wiki/something.md#anchor or wiki/something.md
+    match = re.search(r'(\w+/[\w-]+\.md(?:#[\w-]+)?)', answer)
+    if match:
+        return match.group(1)
+    return ""
+
+
+async def run_agentic_loop(
+    question: str,
+    config: dict[str, str],
+) -> tuple[str, str, list[dict[str, Any]]]:
+    """
+    Run the agentic loop to answer a question.
     
-    return answer
+    Args:
+        question: User's question
+        config: LLM configuration
+        
+    Returns:
+        Tuple of (answer, source, tool_calls)
+    """
+    # Initialize conversation with system prompt
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": question},
+    ]
+    
+    tool_calls: list[dict[str, Any]] = []
+    tool_call_count = 0
+    
+    while tool_call_count < MAX_TOOL_CALLS:
+        print(f"Calling LLM (iteration {tool_call_count + 1})...", file=sys.stderr)
+        
+        # Call LLM with tools
+        response_data = await call_llm(messages, config, tools=TOOLS)
+        
+        if response_data is None:
+            return ("Error: Failed to get response from LLM", "", tool_calls)
+        
+        try:
+            choice = response_data["choices"][0]
+            message = choice["message"]
+        except (KeyError, IndexError) as e:
+            print(f"Error parsing LLM response: {e}", file=sys.stderr)
+            print(f"Response: {response_data}", file=sys.stderr)
+            return ("Error: Failed to parse LLM response", "", tool_calls)
+        
+        # Check for tool calls
+        tool_calls_in_response = message.get("tool_calls", [])
+        
+        if not tool_calls_in_response:
+            # No tool calls - this is the final answer
+            answer = message.get("content", "No answer provided")
+            source = extract_source(answer)
+            return (answer, source, tool_calls)
+        
+        # Execute tool calls
+        for tool_call in tool_calls_in_response:
+            if tool_call_count >= MAX_TOOL_CALLS:
+                break
+            
+            tool_call_id = tool_call.get("id", "")
+            function = tool_call.get("function", {})
+            tool_name = function.get("name", "")
+            
+            # Parse arguments - API returns 'arguments' as JSON string
+            tool_args = {}
+            args_str = function.get("arguments", "{}")
+            try:
+                tool_args = json.loads(args_str)
+            except json.JSONDecodeError:
+                tool_args = {}
+            
+            print(f"Executing tool: {tool_name} with args: {tool_args}", file=sys.stderr)
+            
+            # Execute the tool
+            result = execute_tool(tool_name, tool_args)
+            
+            # Record the tool call
+            tool_calls.append({
+                "tool": tool_name,
+                "args": tool_args,
+                "result": result[:500] if len(result) > 500 else result,  # Truncate for output
+            })
+            
+            # Add assistant message with tool call
+            messages.append({
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [tool_call],
+            })
+            
+            # Add tool response to messages
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "content": result,
+            })
+            
+            tool_call_count += 1
+    
+    # Max tool calls reached - try to get an answer
+    print("Max tool calls reached, requesting final answer...", file=sys.stderr)
+    messages.append({
+        "role": "user",
+        "content": "Please provide your final answer based on the information gathered so far. Include the source reference.",
+    })
+    
+    response_data = await call_llm(messages, config, tools=None)
+    
+    if response_data is None:
+        return ("Error: Max tool calls reached without a final answer", "", tool_calls)
+    
+    try:
+        choice = response_data["choices"][0]
+        message = choice["message"]
+        answer = message.get("content", "No answer provided")
+    except (KeyError, IndexError):
+        answer = "Error: Max tool calls reached without a final answer"
+    
+    source = extract_source(answer)
+    
+    return (answer, source, tool_calls)
 
 
 def main() -> None:
@@ -89,13 +403,14 @@ def main() -> None:
     config = load_env()
     print(f"Using model: {config['LLM_MODEL']}", file=sys.stderr)
     
-    # Call LLM
-    answer = asyncio.run(call_llm(question, config))
+    # Run agentic loop
+    answer, source, tool_calls = asyncio.run(run_agentic_loop(question, config))
     
     # Output result as JSON
     result = {
         "answer": answer,
-        "tool_calls": [],
+        "source": source,
+        "tool_calls": tool_calls,
     }
     print(json.dumps(result))
 

--- a/plans/task-2.md
+++ b/plans/task-2.md
@@ -1,0 +1,208 @@
+# Task 2: The Documentation Agent - Implementation Plan
+
+## Overview
+
+Transform the Task 1 CLI chatbot into a true **agent** by adding tools and an agentic loop. The agent will be able to navigate the project wiki using `read_file` and `list_files` tools to find answers.
+
+## LLM Provider and Model
+
+**Provider:** Qwen Code API (via qwen-code-oai-proxy)
+**Model:** `qwen3-coder-plus`
+
+**Rationale:** Strong tool-calling capabilities, already configured from Task 1.
+
+## Tool Definitions
+
+### 1. `read_file`
+
+**Purpose:** Read contents of a file from the project repository.
+
+**Parameters:**
+- `path` (string, required): Relative path from project root
+
+**Returns:** File contents as string, or error message if file doesn't exist.
+
+**Security:**
+- Reject paths containing `../` (path traversal)
+- Reject absolute paths
+- Only allow files within project root
+
+**Schema:**
+```json
+{
+  "name": "read_file",
+  "description": "Read a file from the project repository",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string",
+        "description": "Relative path from project root (e.g., 'wiki/git-workflow.md')"
+      }
+    },
+    "required": ["path"]
+  }
+}
+```
+
+### 2. `list_files`
+
+**Purpose:** List files and directories at a given path.
+
+**Parameters:**
+- `path` (string, required): Relative directory path from project root
+
+**Returns:** Newline-separated listing of entries.
+
+**Security:**
+- Reject paths containing `../` (path traversal)
+- Reject absolute paths
+- Only allow directories within project root
+
+**Schema:**
+```json
+{
+  "name": "list_files",
+  "description": "List files and directories at a given path",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string",
+        "description": "Relative directory path from project root (e.g., 'wiki')"
+      }
+    },
+    "required": ["path"]
+  }
+}
+```
+
+## Agentic Loop Design
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Agentic Loop                                  │
+│                                                                  │
+│  1. Send question + tool definitions to LLM                      │
+│         │                                                        │
+│         ▼                                                        │
+│  2. Parse LLM response                                           │
+│         │                                                        │
+│         ├─ Has tool_calls? ──yes──▶ 3. Execute tools            │
+│         │                        4. Append results as messages   │
+│         │                        5. Loop back to step 1          │
+│         │                                                        │
+│         no                                                       │
+│         │                                                        │
+│         ▼                                                        │
+│  6. Extract answer + source                                      │
+│  7. Output JSON and exit                                         │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Loop Steps
+
+1. **Initial Request:** Send user question with system prompt and tool definitions
+2. **Parse Response:** Check if LLM returned `tool_calls` or a final answer
+3. **Execute Tools:** For each tool call, execute the corresponding function
+4. **Append Results:** Add tool results as `tool` role messages
+5. **Continue Loop:** Send updated conversation back to LLM
+6. **Final Answer:** When no tool calls, extract answer and source
+7. **Output:** Return JSON with `answer`, `source`, and `tool_calls`
+
+### Loop Limits
+
+- Maximum 10 tool calls per question
+- Timeout: 60 seconds total
+
+## System Prompt Strategy
+
+The system prompt will instruct the LLM to:
+
+1. Use `list_files` to discover wiki directory structure
+2. Use `read_file` to read relevant wiki files
+3. Find the specific section that answers the question
+4. Include the source reference (file path + section anchor)
+5. Only make tool calls when necessary
+
+**Example System Prompt:**
+```
+You are a documentation agent that answers questions using the project wiki.
+
+You have access to two tools:
+- list_files: List files in a directory
+- read_file: Read contents of a file
+
+To answer questions:
+1. First use list_files to explore the wiki directory
+2. Use read_file to read relevant files
+3. Find the specific section that answers the question
+4. Include the source as "filepath.md#section-anchor"
+
+Always provide the source reference for your answer.
+```
+
+## Output Format
+
+```json
+{
+  "answer": "The answer text from the LLM",
+  "source": "wiki/git-workflow.md#resolving-merge-conflicts",
+  "tool_calls": [
+    {
+      "tool": "list_files",
+      "args": {"path": "wiki"},
+      "result": "git-workflow.md\n..."
+    },
+    {
+      "tool": "read_file",
+      "args": {"path": "wiki/git-workflow.md"},
+      "result": "..."
+    }
+  ]
+}
+```
+
+## Path Security Implementation
+
+```python
+def is_safe_path(path: str) -> bool:
+    """Check if path is safe (no traversal outside project root)."""
+    # Reject absolute paths
+    if path.startswith('/'):
+        return False
+    # Reject path traversal
+    if '..' in path.split('/'):
+        return False
+    # Reject paths starting with ../
+    if path.startswith('../'):
+        return False
+    return True
+```
+
+## Files to Modify/Create
+
+1. `plans/task-2.md` - This implementation plan
+2. `agent.py` - Add tools and agentic loop
+3. `AGENT.md` - Update with tools documentation
+4. `tests/test_agent.py` - Add 2 regression tests
+
+## Testing Strategy
+
+**Test 1:** Question about merge conflicts
+- Input: `"How do you resolve a merge conflict?"`
+- Expected: `read_file` in tool_calls, `wiki/git-workflow.md` in source
+
+**Test 2:** Question about wiki files
+- Input: `"What files are in the wiki?"`
+- Expected: `list_files` in tool_calls
+
+## Success Criteria
+
+- [ ] Tools `read_file` and `list_files` implemented
+- [ ] Agentic loop executes and feeds results back
+- [ ] Output includes `answer`, `source`, and `tool_calls`
+- [ ] Path security prevents directory traversal
+- [ ] Maximum 10 tool calls enforced
+- [ ] 2 regression tests pass

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,4 +1,4 @@
-"""Regression tests for agent.py CLI."""
+"""Regression tests for agent.py CLI - Task 2: Documentation Agent."""
 
 import json
 import subprocess
@@ -20,8 +20,24 @@ def agent_script(project_root: Path) -> Path:
     return project_root / "agent.py"
 
 
-class TestAgentOutput:
-    """Test agent.py output format."""
+def run_agent(question: str, project_root: Path) -> dict:
+    """Run the agent and return the parsed JSON output."""
+    result = subprocess.run(
+        ["uv", "run", "agent.py", question],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=project_root,
+    )
+    
+    # Parse stdout as JSON (last line)
+    stdout_lines = result.stdout.strip().split("\n")
+    json_line = stdout_lines[-1]
+    return json.loads(json_line)
+
+
+class TestTask1BasicOutput:
+    """Test basic JSON output format (Task 1)."""
 
     def test_agent_returns_valid_json(self, agent_script: Path) -> None:
         """Test that agent.py outputs valid JSON with required fields."""
@@ -36,9 +52,9 @@ class TestAgentOutput:
         # Check exit code
         assert result.returncode == 0, f"Agent failed: {result.stderr}"
 
-        # Parse stdout as JSON (only the last line, which is the JSON output)
+        # Parse stdout as JSON
         stdout_lines = result.stdout.strip().split("\n")
-        json_line = stdout_lines[-1]  # Last line should be the JSON
+        json_line = stdout_lines[-1]
 
         try:
             output = json.loads(json_line)
@@ -53,5 +69,55 @@ class TestAgentOutput:
         assert isinstance(output["answer"], str), "'answer' must be a string"
         assert isinstance(output["tool_calls"], list), "'tool_calls' must be an array"
 
+        # Check answer is non-empty
+        assert len(output["answer"].strip()) > 0, "'answer' must not be empty"
+
+
+class TestTask2DocumentationAgent:
+    """Test documentation agent with tools (Task 2)."""
+
+    def test_list_files_tool(self, project_root: Path) -> None:
+        """Test that agent uses list_files tool for wiki directory question."""
+        output = run_agent("What files are in the wiki?", project_root)
+        
+        # Check required fields exist
+        assert "answer" in output, "Missing 'answer' field"
+        assert "source" in output, "Missing 'source' field"
+        assert "tool_calls" in output, "Missing 'tool_calls' field"
+        
+        # Check that list_files was called
+        tool_names = [tc.get("tool") for tc in output["tool_calls"]]
+        assert "list_files" in tool_names, "Expected list_files tool to be called"
+        
+        # Check that list_files was called with wiki path
+        list_files_calls = [tc for tc in output["tool_calls"] if tc.get("tool") == "list_files"]
+        assert len(list_files_calls) > 0, "list_files was not called"
+        
+        for call in list_files_calls:
+            args = call.get("args", {})
+            if args.get("path") == "wiki":
+                break
+        else:
+            pytest.fail("list_files was not called with path='wiki'")
+        
+        # Check answer is non-empty
+        assert len(output["answer"].strip()) > 0, "'answer' must not be empty"
+
+    def test_read_file_tool_for_merge_conflict(self, project_root: Path) -> None:
+        """Test that agent uses read_file tool for merge conflict question."""
+        output = run_agent("How do you resolve a merge conflict?", project_root)
+        
+        # Check required fields exist
+        assert "answer" in output, "Missing 'answer' field"
+        assert "source" in output, "Missing 'source' field"
+        assert "tool_calls" in output, "Missing 'tool_calls' field"
+        
+        # Check that read_file was called
+        tool_names = [tc.get("tool") for tc in output["tool_calls"]]
+        assert "read_file" in tool_names, "Expected read_file tool to be called"
+        
+        # Check that list_files was also called (to discover files)
+        assert "list_files" in tool_names, "Expected list_files tool to be called"
+        
         # Check answer is non-empty
         assert len(output["answer"].strip()) > 0, "'answer' must not be empty"


### PR DESCRIPTION
- Add read_file and list_files tools with path security
- Implement agentic loop with max 10 tool calls
- Update output format with answer, source, and tool_calls fields
- Add plans/task-2.md implementation plan
- Add 2 regression tests for tool calling
- Update AGENT.md documentation

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #5 

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [x] I see `base: main` <- `compare: <branch>` above the PR title.
- [x] I edited the line `- Closes #<issue-number>`.
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I’m submitting.
